### PR TITLE
Applying fix for signup to the rest of our classes in Application.scss

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -331,7 +331,7 @@ a:hover {
     display: flex;
     justify-content: center;
     align-items: center;
-    background-image: url(../assets/manwithbar.png);
+    background-image: url(../photos/manwithbar.png);
     min-height: 100vh;
     background-size: cover;
     background-repeat: no-repeat;
@@ -377,7 +377,7 @@ a:hover {
         display: flex;
         justify-content: center;
         align-items: center;
-        background-image: url(../assets/girl.png);
+        background-image: url(../photos/girl.png);
         min-height: 100vh;
         background-size: cover;
         background-repeat: no-repeat;


### PR DESCRIPTION
Fix for images is now applied to all of our images when deployed on Heroku.

Previous state
background-image: url(../assets/girl.png) This was inside of the assets folder in app/assets/images. Heroku doesn't like this.

Created a folder in the public folder named photos.
Changed Application.SCSS to:
classes for signup/login/password
    
background-image: url(../photos/girl.png);



